### PR TITLE
fix ansible warning

### DIFF
--- a/roles/mastodon/tasks/ufw.yml
+++ b/roles/mastodon/tasks/ufw.yml
@@ -2,7 +2,7 @@
 - name: Allow ssh through firewall
   ufw:
     proto: tcp
-    port: 22
+    port: '22'
     rule: allow
 
 - name: Set ufw policy
@@ -14,11 +14,11 @@
 - name: Allow nginx firewall
   ufw:
     proto: tcp
-    port: 80
+    port: '80'
     rule: allow
 
 - name: Allow nginx ssl firewall
   ufw:
     proto: tcp
-    port: 443
+    port: '443'
     rule: allow


### PR DESCRIPTION
[WARNING]: The value 22,80,443 (type int) in a string field was converted to '22','80','443' (type string). If this does not look like what you expect, quote the entire
value to ensure it does not change.