### PR TITLE
Fix LE Cert not being generated for www.

### DIFF
--- a/roles/mastodon/tasks/letsencrypt.yml
+++ b/roles/mastodon/tasks/letsencrypt.yml
@@ -3,11 +3,16 @@
   stat: path=/etc/letsencrypt/live/{{ mastodon_host }}/fullchain.pem
   register: letsencrypt_cert
 
+- name: Copy initial letsencrypt nginx server config
+  template:
+    src: nginx/letsencrypt-server.conf.j2
+    dest: /etc/nginx/letsencrypt.conf
+  when: not letsencrypt_cert.stat.exists
+
 - name: Copy letsencrypt nginx config
   template:
     src: nginx/letsencrypt.conf.j2
-    dest: /etc/nginx/sites-available/mastodon.conf
-  when: not letsencrypt_cert.stat.exists
+    dest: /etc/nginx/letsencrypt.conf
 
 - name: Symlink enabled site
   file:
@@ -26,7 +31,7 @@
   - reload nginx
 
 - name: Install letsencrypt cert
-  command: certbot certonly -n --webroot -d www.{{ mastodon_host }} -d {{ mastodon_host }} -w {{ mastodon_path }}/public/ --email "webmaster@{{ mastodon_host }}" --rsa-key-size 4096 --agree-tos
+  command: certbot certonly -n --webroot -d {{ mastodon_host }} -d www.{{ mastodon_host }} -w {{ mastodon_path }}/public/ --email "webmaster@{{ mastodon_host }}" --rsa-key-size 4096 --agree-tos
   when: not letsencrypt_cert.stat.exists and enable_www_redirect
   notify:
   - reload nginx

--- a/roles/mastodon/templates/nginx/letsencrypt-server.conf.j2
+++ b/roles/mastodon/templates/nginx/letsencrypt-server.conf.j2
@@ -1,0 +1,8 @@
+# This starts a simple nginx for the letsencrypt acme challenge
+server {
+  listen 80;
+  listen [::]:80;
+  server_name {{ mastodon_host }};
+  root {{ mastodon_path }}/public;
+  location /.well-known/acme-challenge/ { allow all; }
+}

--- a/roles/mastodon/templates/nginx/letsencrypt.conf.j2
+++ b/roles/mastodon/templates/nginx/letsencrypt.conf.j2
@@ -1,8 +1,4 @@
 # This starts a simple nginx for the letsencrypt acme challenge
-server {
-  listen 80;
-  listen [::]:80;
-  server_name {{ mastodon_host }};
-  root {{ mastodon_path }}/public;
-  location /.well-known/acme-challenge/ { allow all; }
+location /.well-known/acme-challenge/ { 
+	root {{ mastodon_path }}/public;
 }

--- a/roles/mastodon/templates/nginx/mastodon.conf.j2
+++ b/roles/mastodon/templates/nginx/mastodon.conf.j2
@@ -8,10 +8,9 @@ server {
   listen [::]:80;
   server_name {{ mastodon_host }};
 
-  # Useful for Let's Encrypt
-  location /.well-known/acme-challenge/ { 
-    alias {{ mastodon_path }}/public/.well-known/acme-challenge/;
-  }
+	{% if not (disable_letsencrypt | bool) %}
+		include letsencrypt.conf;
+	{% endif %}
   location / { return 301 https://$host$request_uri; }
 }
 
@@ -116,9 +115,10 @@ server {
   server_name www.{{ mastodon_host }};
 
   # Useful for Let's Encrypt
-  location /.well-known/acme-challenge/ { 
-    alias {{ mastodon_home }}/{{ mastodon_path }}/public/.well-known/acme-challenge/;
-  }
+	{% if not (disable_letsencrypt | bool) %}
+		include letsencrypt.conf;
+	{% endif %}
+
   location / { return 301 https://$host$request_uri; }
 }
 
@@ -140,6 +140,10 @@ server {
 {% if not (disable_hsts | bool) %}
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always; 
 {% endif %}
+
+	{% if not (disable_letsencrypt | bool) %}
+		include letsencrypt.conf;
+	{% endif %}
 
   location / { return 301 https://{{ mastodon_host }}$request_uri; }
 }


### PR DESCRIPTION
The appropriate nginx config block for matching the well known directory
to the appropriate folder was missing in the www. config block.

When it's being deployed, it may be needed to delte the old ssl
certificate in `/etc/letsencrypt/live/`, `/etc/letsencrypt/renewal/`
and `/etc/letsencrypt/archive/cuties.social` manually before deploying
again.
