### PR TITLE
Update Mastodon to v3.3.0

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -7,11 +7,14 @@ mastodon_user: "mastodon"
 mastodon_home: "/home/{{ mastodon_user }}"
 mastodon_db_user: "{{ mastodon_user }}"
 mastodon_path: "{{ mastodon_home }}/live"
+mastodon_version: 'v3.3.0'
+
 mastodon_db: "{{ mastodon_user }}_cuties_social"
 mastodon_db_port: 5432
 disable_hsts: "false"
 disable_letsencrypt: "false"
 enable_www_redirect: "true"
+
 mastodon_db_password: !vault |
           $ANSIBLE_VAULT;1.1;AES256
           63646261303530326663613262353536383931313838323536396535333036396138386134363763
@@ -19,6 +22,7 @@ mastodon_db_password: !vault |
           62356163343064646565366439386436626462623038636236643538393938636434343564653834
           3332636538376230650a353261383038653930643739303034376137363866336264616332336233
           37656139653634656435623732303039313162656664336565383438366661316136
+
 mastodon_host: cuties.social
 
 mastodon_acme_server: 'https://api.buypass.com/acme/directory'

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,4 +1,5 @@
-ruby_version: 2.6.6
+---
+ruby_version: 2.7.2
 rbenv_version: v1.1.2
 ruby_build_version: v20200401
 os_family: "{{ ansible_os_family|lower }}"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,7 +1,7 @@
 ---
 ruby_version: 2.7.2
 rbenv_version: v1.1.2
-ruby_build_version: v20200401
+ruby_build_version: v20201225
 os_family: "{{ ansible_os_family|lower }}"
 mastodon_user: "mastodon"
 mastodon_home: "/home/{{ mastodon_user }}"

--- a/roles/mastodon/tasks/mastodon.yml
+++ b/roles/mastodon/tasks/mastodon.yml
@@ -111,6 +111,7 @@
     chdir: "{{ mastodon_path }}"
   environment:
     RAILS_ENV: production
+    PATH: '{{ mastodon_home }}/.rbenv/shims:{{ ansible_env.PATH }}'
 
 - name: Run post-deployment migrations
   command:

--- a/roles/mastodon/tasks/mastodon.yml
+++ b/roles/mastodon/tasks/mastodon.yml
@@ -57,9 +57,15 @@
 - include_tasks: patches/main.yml
   when: mastodon_patches_enable
 
-- name: Migrate database
-  shell: "RAILS_ENV=production ~/.rbenv/shims/bundle exec rails db:migrate"
-  args:
+- name: Run pre-deployment migrations
+  command:
+    argv:
+      - SKIP_POST_DEPLOYMENT_MIGRATIONS=true
+      - RAILS_ENV=production
+      - ~/.rbenv/shims/bundle
+      - exec
+      - rails
+      - db:migrate
     chdir: "{{ mastodon_path }}"
 
 - name: Precompile assets
@@ -99,8 +105,31 @@
   become: true
   become_user: root
 
+- name: Clear cache
+  command:
+    argv:
+      - RAILS_ENV=production
+      - bin/tootctl
+      - cache
+      - clear
+    chdir: "{{ mastodon_path }}"
+
+- name: Run post-deployment migrations
+  command:
+    argv:
+      - RAILS_ENV=production
+      - ~/.rbenv/shims/bundle
+      - exec
+      - rails
+      - db:migrate
+    chdir: "{{ mastodon_path }}"
 
 - name: import old statuses to elasticsearch
-  shell: "RAILS_ENV=production ~/.rbenv/shims/bundle exec rake chewy:sync"
-  args:
+  command:
+    argv:
+      - RAILS_ENV=production
+      - ~/.rbenv/shims/bundle
+      - exec
+      - rake
+      - chewy:sync
     chdir: "{{ mastodon_path }}"

--- a/roles/mastodon/tasks/mastodon.yml
+++ b/roles/mastodon/tasks/mastodon.yml
@@ -56,13 +56,14 @@
 - name: Run pre-deployment migrations
   command:
     argv:
-      - SKIP_POST_DEPLOYMENT_MIGRATIONS=true
-      - RAILS_ENV=production
       - ~/.rbenv/shims/bundle
       - exec
       - rails
       - db:migrate
     chdir: "{{ mastodon_path }}"
+  environment:
+    SKIP_POST_DEPLOYMENT_MIGRATIONS: true
+    RAILS_ENV: production
 
 - name: Precompile assets
   shell: "RAILS_ENV=production ~/.rbenv/shims/bundle exec rails assets:precompile"
@@ -104,28 +105,31 @@
 - name: Clear cache
   command:
     argv:
-      - RAILS_ENV=production
       - bin/tootctl
       - cache
       - clear
     chdir: "{{ mastodon_path }}"
+  environment:
+    RAILS_ENV: production
 
 - name: Run post-deployment migrations
   command:
     argv:
-      - RAILS_ENV=production
       - ~/.rbenv/shims/bundle
       - exec
       - rails
       - db:migrate
     chdir: "{{ mastodon_path }}"
+  environment:
+    RAILS_ENV: production
 
 - name: import old statuses to elasticsearch
   command:
     argv:
-      - RAILS_ENV=production
       - ~/.rbenv/shims/bundle
       - exec
       - rake
       - chewy:sync
     chdir: "{{ mastodon_path }}"
+  environment:
+    RAILS_ENV: production

--- a/roles/mastodon/tasks/mastodon.yml
+++ b/roles/mastodon/tasks/mastodon.yml
@@ -4,12 +4,8 @@
     repo: "https://github.com/tootsuite/mastodon.git"
     dest: "{{ mastodon_path }}"
     clone: true
-    force: yes
-
-- name: Update to latest version
-  shell: "git fetch; git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)"
-  args:
-    chdir: "{{ mastodon_path }}"
+    force: true
+    version: "{{ mastodon_version }}"
 
 - name: Bundle install
   shell: "~/.rbenv/shims/bundle install -j$(getconf _NPROCESSORS_ONLN) --deployment --without development test"

--- a/roles/mastodon/tasks/patches/character_limit.yml
+++ b/roles/mastodon/tasks/patches/character_limit.yml
@@ -5,7 +5,7 @@
     regexp: 'MAX_CHARS = '
     line: '  MAX_CHARS = (ENV["MAX_TOOT_CHARS"] || 500).to_i'
 
-- name: patch compose form 1/4
+- name: patch compose form 1/3
   blockinfile:
     path: "{{ mastodon_path }}/app/javascript/mastodon/features/compose/components/compose_form.js"
     block: |
@@ -14,20 +14,14 @@
     insertbefore: "import Icon from 'mastodon/components/icon';"
     marker: "// {mark} ANSIBLE MANAGED BLOCK"
 
-- name: patch compose form 2/4
+- name: patch compose form 2/3
   lineinfile:
     path: "{{ mastodon_path }}/app/javascript/mastodon/features/compose/components/compose_form.js"
-    regexp: if \(isSubmitting \|\| isUploading \|\| isChangingUpload \|\| length\(fulltext\) > .* \|\| \(fulltext.length !== 0 && fulltext.trim\(\).length === 0 && !anyMedia\)\) {
-    line: "    if (isSubmitting || isUploading || isChangingUpload || length(fulltext) > maxChars || (fulltext.length !== 0 && fulltext.trim().length === 0 && !anyMedia)) {"
+    regexp: return !\(isSubmitting \|\| isUploading \|\| isChangingUpload \|\| length\(fulltext\) > .* \|\| \(isOnlyWhitespace && !anyMedia\)\);
+    line: "    return !(isSubmitting || isUploading || isChangingUpload || length(fulltext) > maxChars || (isOnlyWhitespace && !anyMedia));"
 
-- name: patch compose form 3/4
+- name: patch compose form 3/3
   lineinfile:
     path: "{{ mastodon_path }}/app/javascript/mastodon/features/compose/components/compose_form.js"
-    regexp: const disabledButton = disabled \|\| this.props.isUploading \|\| this.props.isChangingUpload \|\| length\(text\) > .* \|\| \(text.length !== 0 && text.trim\(\).length === 0 && !anyMedia\);
-    line: "    const disabledButton = disabled || this.props.isUploading || this.props.isChangingUpload || length(text) > maxChars || (text.length !== 0 && text.trim().length === 0 && !anyMedia);"
-
-- name: patch compose form 4/4
-  lineinfile:
-    path: "{{ mastodon_path }}/app/javascript/mastodon/features/compose/components/compose_form.js"
-    regexp: <div className='character-counter__wrapper'><CharacterCounter max=\{.*\} text={text} \/><\/div>
-    line: "         <div className='character-counter__wrapper'><CharacterCounter max={maxChars} text={text} /></div>"
+    regexp: <div className='character-counter__wrapper'>
+    line: "         <div className='character-counter__wrapper'><CharacterCounter max={maxChars} text={this.getFulltextForCharacterCounting()} /></div>"

--- a/roles/mastodon/tasks/patches/main.yml
+++ b/roles/mastodon/tasks/patches/main.yml
@@ -37,11 +37,11 @@
 - name: patch instance serializer 2/2
   lineinfile:
     path: "{{ mastodon_path }}/app/serializers/rest/instance_serializer.rb"
-    regexp: ':languages, :registrations, :approval_required'
-    line: '             :languages, :registrations, :approval_required, {{ additional_serializers }}'
+    regexp: ':languages, :registrations, :approval_required, :invites_enabled'
+    line: '             :languages, :registrations, :approval_required, :invites_enabled, {{ additional_serializers }}'
 
 - name: patch obfuscatedCount
   lineinfile:
-    path: "{{ mastodon_path }}/app/javascript/mastodon/components/status_action_bar.js"
+    path: "{{ mastodon_path }}/app/javascript/mastodon/components/animated_number.js"
     regexp: "return '1\\+';"
     line: "    return count;"

--- a/roles/mastodon/tasks/patches/userdata.yml
+++ b/roles/mastodon/tasks/patches/userdata.yml
@@ -35,8 +35,8 @@
 - name: patch profile page 1/2
   lineinfile:
     path: "{{ mastodon_path }}/app/views/settings/profiles/show.html.haml"
-    regexp: '= f.input :display_name, wrapper: :with_label, input_html: { maxlength: .* }, hint: false'
-    line: '      = f.input :display_name, wrapper: :with_label, input_html: { maxlength: Account::MAX_DISPLAY_NAME_LENGTH }, hint: false'
+    regexp: '= f.input :display_name, wrapper: :with_label, input_html: { maxlength: .*, data: { default: @account.username } }, hint: false'
+    line: '      = f.input :display_name, wrapper: :with_label, input_html: { maxlength: Account::MAX_DISPLAY_NAME_LENGTH, data: { default: @account.username } }, hint: false'
 
 - name: patch profile page 2/2
   lineinfile:
@@ -54,4 +54,4 @@
   lineinfile:
     path: "{{ mastodon_path }}/spec/models/account_spec.rb"
     regexp: account = Fabricate.build\(:account, note
-    line: '        account = Fabricate.build(:account, note: Faker::Lorem.characters({{ mastodon_bio_character_limit+1 }}))'
+    line: '        account = Fabricate.build(:account, note: Faker::Lorem.characters(number: {{ mastodon_bio_character_limit+1 }}))'


### PR DESCRIPTION
- Bump ruby version to 2.7.2 (093387b)
- Implement upgrade tipps for v3.3.0 (070d98d)
- Enable version pinning for mastodon (a054262, Close #27)
- Updated patches to Mastodon v3.3 (284bf22)
- Update ruby_build_version (d088ebb)
- Fix syntax for env-vars in command module (7f4c5e7)
- Add rbenv to PATH (bfa96d6)