### PR TITLE
Mastodon v3.5.0

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -7,7 +7,7 @@ mastodon_user: "mastodon"
 mastodon_home: "/home/{{ mastodon_user }}"
 mastodon_db_user: "{{ mastodon_user }}"
 mastodon_path: "{{ mastodon_home }}/live"
-mastodon_version: 'v3.4.6'
+mastodon_version: 'v3.5.0'
 
 mastodon_db: "{{ mastodon_user }}_cuties_social"
 mastodon_db_port: 5432

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,7 +1,7 @@
 ---
-ruby_version: 2.7.2
-rbenv_version: v1.1.2
-ruby_build_version: v20201225
+ruby_version: 3.0.3
+rbenv_version: v1.2.0
+ruby_build_version: 20220324
 os_family: "{{ ansible_os_family|lower }}"
 mastodon_user: "mastodon"
 mastodon_home: "/home/{{ mastodon_user }}"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -31,7 +31,7 @@
   vars:
     update_java: true
     es_java_install: true
-    es_version: 6.8.7
+    es_version: 7.17.2
     es_allow_downgrades: true
     es_data_dirs:
       - "/var/elasticsearch/data"
@@ -39,13 +39,8 @@
     es_config:
       node.name: "node1"
       cluster.name: "cutes-cluster"
-      #discovery.seed_hosts: "localhost:9301"
-      #http.port: "{{ mastodon_es_port }}"
-      #transport.port: 9301
       node.master: true
-      #bootstrap.memory_lock: true
     es_heap_size: 1g
-    #es_api_port: "{{ mastodon_es_port }}"
   tags:
     - elasticsearch
 

--- a/roles/mastodon/tasks/mastodon.yml
+++ b/roles/mastodon/tasks/mastodon.yml
@@ -38,6 +38,20 @@
   become: true
   become_user: root
 
+- name: Install systemd elasticsearch-index Service Files
+  template:
+    src: systemd/mastodon-elasticsearch.service.j2
+    dest: /etc/systemd/system/mastodon-elasticsearch.service
+  become: true
+  become_user: root
+  register: elasticsearch_import_service
+
+- name: Ensure mastodon-elasticsearch.service is enabled
+  systemd:
+    name: mastodon-elasticsearch.service
+    daemon_reload: elasticsearch_import_service.changed
+    enabled: true
+
 - name: Media cleanup cronjob
   cron:
     name: "media cleanup"
@@ -70,10 +84,12 @@
   args:
     chdir: "{{ mastodon_path }}"
 
-- name: Create elasticsearch index
-  shell: "RAILS_ENV=production ~/.rbenv/shims/bundle exec rake chewy:upgrade"
-  args:
-    chdir: "{{ mastodon_path }}"
+- name: Create elasticsearch index in background
+  systemd:
+    name: mastodon-elasticsearch.service
+    state: restarted
+  become: true
+  become_user: root
 
 - name: Enable and restart mastodon-web
   systemd:

--- a/roles/mastodon/tasks/ruby.yml
+++ b/roles/mastodon/tasks/ruby.yml
@@ -40,7 +40,7 @@
   check_mode: no
 
 - name: Install Ruby {{ ruby_version }}
-  shell: "~/.rbenv/bin/rbenv install {{ ruby_version }}"
+  shell: "RUBY_CONFIGURE_OPTS=--with-jemalloc ~/.rbenv/bin/rbenv install {{ ruby_version }}"
   args:
     executable: /bin/bash
   when: ruby_installed is failed

--- a/roles/mastodon/templates/systemd/mastodon-elasticsearch.service.j2
+++ b/roles/mastodon/templates/systemd/mastodon-elasticsearch.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Create mastodon elasticsearch index
+After=elasticsearch.service
+After=system-postgresql.slice
+
+[Service]
+Type=oneshot
+User=mastodon
+WorkingDirectory={{ mastodon_path }}
+Environment="RAILS_ENV=production"
+ExecStart={{ mastodon_home }}/.rbenv/shims/bundle exec rake chewy:upgrade
+StandardOutput=journal
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Incorporate changed requirements etc. as shown here: https://github.com/mastodon/mastodon/releases/tag/v3.5.0

- Bump ruby to 3.0.3
- Add `with-jemalloc` Ruby
- Bump elasticsearch to 7.17.0
- Create systemd service to create elasticsearch index in the background (for faster deployment)
- Most important: Update Mastodon to version 3.5.0